### PR TITLE
Add pre-commit script to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ We also encourage to use [husky](https://github.com/typicode/husky) and [lint-st
 
 ```json
 {
+  "scripts": {
+    "precommit": "lint-staged" 
+  },
   "lint-staged": {
     "linters": {
       "src/**/*.js": [


### PR DESCRIPTION
When I was setting up prettier-standard in my project, I got stuck when following the current example in the README. Because no `pre-commit` script was included in the example, I never included it, and then could not figure out why my git hooks weren't running. 

I know this problem isn't specific to `prettier-standard`, but because you're providing example, I think it should be more fleshed out.

I'll also be writing a blog post with an example of how to set this up, if that would be useful for this README.